### PR TITLE
TKH-3141 Correctly handle WriteOnly fields

### DIFF
--- a/model/modelbuilder.go
+++ b/model/modelbuilder.go
@@ -336,7 +336,7 @@ func buildType(parentType *restClassType, baseTypeName string, propertyName stri
 	if ref.Ref != "" && schema.Type.Is("string") && len(schema.Enum) > 0 {
 		enumName := refToName(ref.Ref)
 		enum := getOrBuildTypeModel(types, enumName, ref, nil)
-		return NewEnumPropertyType(enum, rsSchemaTemplateBase)
+		return NewEnumPropertyType(restProperty, enum, rsSchemaTemplateBase)
 	}
 	if schema.Type.Is("boolean") || schema.Type.Is("integer") || schema.Type.Is("string") {
 		return NewRestSimpleType(restProperty, schema, rsSchemaTemplateBase)

--- a/model/modelbuilder.go
+++ b/model/modelbuilder.go
@@ -428,6 +428,7 @@ func buildRSSchemaTemplateBase(ref *openapi3.SchemaRef, propertyName string) map
 	immutable := property.Value.Extensions["x-tkh-immutable"] != nil && property.Value.Extensions["x-tkh-immutable"].(bool)
 	createOnly := property.Value.Extensions["x-tkh-create-only"] != nil && property.Value.Extensions["x-tkh-create-only"].(bool)
 	backendDefault := property.Value.Extensions["x-tkh-backend-determines-default"] != nil && property.Value.Extensions["x-tkh-backend-determines-default"].(bool)
+	writeOnly := property.Value.WriteOnly
 
 	if immutable && !createOnly {
 		return map[string]any{
@@ -453,6 +454,11 @@ func buildRSSchemaTemplateBase(ref *openapi3.SchemaRef, propertyName string) map
 	if backendDefault {
 		return map[string]any{
 			"Mode": "Optional_Computed",
+		}
+	}
+	if writeOnly {
+		return map[string]any{
+			"Mode": "WriteOnly",
 		}
 	}
 	return map[string]any{

--- a/model/property.go
+++ b/model/property.go
@@ -36,7 +36,7 @@ type RestPropertyType interface {
 	RequiresReplace() bool
 	NestedType() RestType
 	TKHToTF(value string, listItem bool) string
-	TFToTKH(value string, listItem bool) string
+	TFToTKH(planValue string, configValue string, listItem bool) string
 	TKHToTFGuard() string
 	TFToTKHGuard() string
 	TKHGetter(propertyName string) string
@@ -132,7 +132,7 @@ func (p *RestProperty) TKHSetter() string {
 }
 
 func (p *RestProperty) TFToTKH() string {
-	return p.Type.TFToTKH("objAttrs[\""+p.TFName()+"\"]", false)
+	return p.Type.TFToTKH("planAttrValues[\""+p.TFName()+"\"]", "configAttrValues[\""+p.TFName()+"\"]", false)
 }
 
 func (p *RestProperty) IsNotComputed() bool {
@@ -143,6 +143,11 @@ func (p *RestProperty) IsNotComputed() bool {
 func (p *RestProperty) IsRequired() bool {
 	mode := p.Type.RSSchemaTemplateData()["Mode"]
 	return mode == "Required"
+}
+
+func (p *RestProperty) IsValueFromConfig() bool {
+	mode := p.Type.RSSchemaTemplateData()["Mode"]
+	return mode == "WriteOnly"
 }
 
 func (p *RestProperty) DS() *RestProperty {

--- a/model/property_type_additional.go
+++ b/model/property_type_additional.go
@@ -92,7 +92,7 @@ func (t *restAdditionalType) TKHToTF(value string, listItem bool) string {
 	return "types.ListNull(types.StringType)"
 }
 
-func (t *restAdditionalType) TFToTKH(value string, listItem bool) string {
+func (t *restAdditionalType) TFToTKH(planValue string, configValue string, listItem bool) string {
 	return ""
 }
 

--- a/model/property_type_array.go
+++ b/model/property_type_array.go
@@ -148,25 +148,29 @@ func (t *restArrayType) TKHToTF(value string, listItem bool) string {
 		"        })"
 }
 
-func (t *restArrayType) TFToTKH(value string, listItem bool) string {
+func (t *restArrayType) TFToTKH(planValue string, configValue string, listItem bool) string {
 	sdkType := t.itemType.SDKTypeName(true)
 	var body string
 	if t.itemType.ToTKHAttrWithDiag() {
-		body = "            tkh, d := " + t.itemType.TFToTKH("val", true) + "\n" +
+		body = "            tkh, d := " + t.itemType.TFToTKH("planValue", "configValue", true) + "\n" +
 			"            diags.Append(d...)\n" +
 			"            return tkh\n"
 	} else {
-		body = "            return " + t.itemType.TFToTKH("val", true) + "\n"
+		body = "            return " + t.itemType.TFToTKH("planValue", "configValue", true) + "\n"
 	}
-	var functionName string
-	if t.setCollection {
-		functionName = "tfToSliceSet"
-	} else {
-		functionName = "tfToSliceList"
-	}
-	return functionName + "(" + value + ".(" + t.TFValueType() + "), func(val attr.Value, diags *diag.Diagnostics) " + sdkType + " {\n" +
+	elementFunction := "func(planValue attr.Value, configValue attr.Value, diags *diag.Diagnostics) " + sdkType + " {\n" +
 		body +
-		"        })"
+		"        }"
+
+	var collectionFunctionName string
+	if t.setCollection {
+		collectionFunctionName = "tfToSliceSet"
+	} else {
+		collectionFunctionName = "tfToSliceListBinary"
+	}
+
+	// basically a foreach construction
+	return collectionFunctionName + "(" + planValue + ".(" + t.TFValueType() + ")," + configValue + ".(" + t.TFValueType() + "), " + elementFunction + ")"
 }
 
 func (t *restArrayType) TKHGetter(propertyName string) string {

--- a/model/property_type_array.go
+++ b/model/property_type_array.go
@@ -68,6 +68,14 @@ func (t *restArrayType) TFValueType() string {
 	}
 }
 
+func (t *restArrayType) TFValueTypeCast() string {
+	if t.setCollection {
+		return "toSetValue"
+	} else {
+		return "toListValue"
+	}
+}
+
 func (t *restArrayType) TFValidatorType() string {
 	if t.setCollection {
 		return "validator.Set"
@@ -170,7 +178,7 @@ func (t *restArrayType) TFToTKH(planValue string, configValue string, listItem b
 	}
 
 	// basically a foreach construction
-	return collectionFunctionName + "(" + planValue + ".(" + t.TFValueType() + ")," + configValue + ".(" + t.TFValueType() + "), " + elementFunction + ")"
+	return collectionFunctionName + "(" + t.TFValueTypeCast() + "(" + planValue + ")," + t.TFValueTypeCast() + "(" + configValue + "), " + elementFunction + ")"
 }
 
 func (t *restArrayType) TKHGetter(propertyName string) string {

--- a/model/property_type_enumproperty.go
+++ b/model/property_type_enumproperty.go
@@ -11,12 +11,14 @@ import (
 )
 
 type restEnumPropertyType struct {
+	property             *RestProperty
 	enumType             *restEnumType
 	rsSchemaTemplateBase map[string]any
 }
 
-func NewEnumPropertyType(enumType RestType, rsSchemaTemplateBase map[string]any) RestPropertyType {
+func NewEnumPropertyType(property *RestProperty, enumType RestType, rsSchemaTemplateBase map[string]any) RestPropertyType {
 	return &restEnumPropertyType{
+		property:             property,
 		enumType:             enumType.(*restEnumType),
 		rsSchemaTemplateBase: rsSchemaTemplateBase,
 	}
@@ -101,7 +103,14 @@ func (t *restEnumPropertyType) TKHToTF(value string, listItem bool) string {
 	return "stringerToTF(" + value + ")"
 }
 
-func (t *restEnumPropertyType) TFToTKH(value string, listItem bool) string {
+func (t *restEnumPropertyType) TFToTKH(planValue string, configValue string, listItem bool) string {
+	var value string
+	if t.property.IsValueFromConfig() {
+		value = configValue
+	} else {
+		value = planValue
+	}
+
 	caster := "func(val any) " + t.SDKTypeName(listItem) + " { return *val.(*" + t.SDKTypeName(listItem) + ") }"
 	if listItem {
 		return "parseCast(" + value + ".(basetypes.StringValue), " + t.SDKTypeConstructor() + ", " + caster + ")"
@@ -155,5 +164,5 @@ func (t *restEnumPropertyType) RSSchemaTemplateData() map[string]any {
 }
 
 func (t *restEnumPropertyType) DS() RestPropertyType {
-	return NewEnumPropertyType(t.enumType.DS(), t.rsSchemaTemplateBase)
+	return NewEnumPropertyType(t.property.DS(), t.enumType.DS(), t.rsSchemaTemplateBase)
 }

--- a/model/property_type_findbasebyuuid.go
+++ b/model/property_type_findbasebyuuid.go
@@ -90,8 +90,8 @@ func (t *restFindBaseByUUIDObjectType) TKHToTF(value string, listItem bool) stri
 	return "withUuidToTF(tkh)"
 }
 
-func (t *restFindBaseByUUIDObjectType) TFToTKH(value string, listItem bool) string {
-	return "find" + t.baseType.superClass.GoTypeName() + "ByUUID(ctx, " + value + ".(basetypes.StringValue).ValueStringPointer())"
+func (t *restFindBaseByUUIDObjectType) TFToTKH(planValue string, configValue string, listItem bool) string {
+	return "find" + t.baseType.superClass.GoTypeName() + "ByUUID(ctx, " + planValue + ".(basetypes.StringValue).ValueStringPointer())"
 }
 
 func (t *restFindBaseByUUIDObjectType) TKHGetter(propertyName string) string {

--- a/model/property_type_findbyuuid.go
+++ b/model/property_type_findbyuuid.go
@@ -89,8 +89,8 @@ func (t *restFindByUUIDObjectType) TKHToTF(value string, listItem bool) string {
 	return "withUuidToTF(" + value + ")"
 }
 
-func (t *restFindByUUIDObjectType) TFToTKH(value string, listItem bool) string {
-	return "find" + t.nestedType.NestedType().GoTypeName() + "ByUUID(ctx, " + value + ".(basetypes.StringValue).ValueStringPointer())"
+func (t *restFindByUUIDObjectType) TFToTKH(planValue string, configValue string, listItem bool) string {
+	return "find" + t.nestedType.NestedType().GoTypeName() + "ByUUID(ctx, " + planValue + ".(basetypes.StringValue).ValueStringPointer())"
 }
 
 func (t *restFindByUUIDObjectType) TKHToTFGuard() string {

--- a/model/property_type_findparentbyuuid.go
+++ b/model/property_type_findparentbyuuid.go
@@ -77,7 +77,7 @@ func (t *restFindParentByUUIDObjectType) TKHToTF(value string, listItem bool) st
 	return "types.StringNull()"
 }
 
-func (t *restFindParentByUUIDObjectType) TFToTKH(value string, listItem bool) string {
+func (t *restFindParentByUUIDObjectType) TFToTKH(planValue string, configValue string, listItem bool) string {
 	return ""
 }
 

--- a/model/property_type_map.go
+++ b/model/property_type_map.go
@@ -118,19 +118,21 @@ func (t *restMapType) TKHToTF(value string, listItem bool) string {
 		"        })"
 }
 
-func (t *restMapType) TFToTKH(value string, listItem bool) string {
+func (t *restMapType) TFToTKH(planValue string, configValue string, listItem bool) string {
 	var body string
 	if t.itemType.ToTKHAttrWithDiag() {
-		body = "            tkh, d := " + t.itemType.TFToTKH("val", true) + "\n" +
+		body = "            tkh, d := " + t.itemType.TFToTKH("planValue", "configValue", true) + "\n" +
 			"            diags.Append(d...)\n" +
 			"            return tkh\n"
 	} else {
-		body = "            return " + t.itemType.TFToTKH("val", true) + "\n"
+		body = "            return " + t.itemType.TFToTKH("planValue", "configValue", true) + "\n"
 	}
 
-	return "tfToMap(" + value + ".(basetypes.MapValue), func(val attr.Value, diags *diag.Diagnostics) any {\n" +
+	elementFunction := "func(planValue attr.Value, configValue attr.Value, diags *diag.Diagnostics) any {\n" +
 		body +
-		"        }, " + t.SDKTypeConstructor() + ")"
+		"        }"
+
+	return "tfToMap(" + planValue + ".(basetypes.MapValue), " + configValue + ".(basetypes.MapValue), " + elementFunction + ", " + t.SDKTypeConstructor() + ")"
 }
 
 func (t *restMapType) TKHGetter(propertyName string) string {

--- a/model/property_type_map.go
+++ b/model/property_type_map.go
@@ -51,6 +51,10 @@ func (t *restMapType) TFValueType() string {
 	return "basetypes.MapValue"
 }
 
+func (t *restMapType) TFValueTypeCast() string {
+	return "toMapValue"
+}
+
 func (t *restMapType) TFValidatorType() string {
 	return "validator.Map"
 }
@@ -132,7 +136,7 @@ func (t *restMapType) TFToTKH(planValue string, configValue string, listItem boo
 		body +
 		"        }"
 
-	return "tfToMap(" + planValue + ".(basetypes.MapValue), " + configValue + ".(basetypes.MapValue), " + elementFunction + ", " + t.SDKTypeConstructor() + ")"
+	return "tfToMap(" + t.TFValueTypeCast() + "(" + planValue + ")," + t.TFValueTypeCast() + "(" + configValue + "), " + elementFunction + ", " + t.SDKTypeConstructor() + ")"
 }
 
 func (t *restMapType) TKHGetter(propertyName string) string {

--- a/model/property_type_nestedobject.go
+++ b/model/property_type_nestedobject.go
@@ -136,18 +136,22 @@ func (t *restNestedObjectType) TKHToTF(value string, listItem bool) string {
 		"(" + RecurseCutOff(t.property.Parent) + ", " + value + ")"
 }
 
-func (t *restNestedObjectType) TFToTKH(value string, listItem bool) string {
-	var tfVal string
+func (t *restNestedObjectType) TFToTKH(planValue string, configValue string, listItem bool) string {
+	var tfPlanVal string
+	var tfConfigVal string
 	if t.FlattenMode() == "AdditionalObjects" {
-		tfVal = "objVal"
+		tfPlanVal = "planValues"
+		tfConfigVal = "configValues"
 	} else if t.FlattenMode() == "ItemsList" {
-		tfVal = `toItemsList(ctx, objAttrs["` + t.property.TFName() + `"])`
+		tfPlanVal = `toItemsList(ctx, planAttrValues["` + t.property.TFName() + `"])`
+		tfConfigVal = `toItemsList(ctx, configAttrValues["` + t.property.TFName() + `"])`
 	} else {
-		tfVal = value + ".(basetypes.ObjectValue)"
+		tfPlanVal = planValue + ".(basetypes.ObjectValue)"
+		tfConfigVal = configValue + ".(basetypes.ObjectValue)"
 	}
 
 	return "tfObjectToTKH" + t.nestedType.Suffix() + t.nestedType.GoTypeName() +
-		"(ctx, " + RecurseCutOff(t.property.Parent) + ", " + tfVal + ")"
+		"(ctx, " + RecurseCutOff(t.property.Parent) + ", " + tfPlanVal + ", " + tfConfigVal + ")"
 }
 
 func (t *restNestedObjectType) TKHToTFGuard() string {

--- a/model/property_type_nestedobject.go
+++ b/model/property_type_nestedobject.go
@@ -146,8 +146,8 @@ func (t *restNestedObjectType) TFToTKH(planValue string, configValue string, lis
 		tfPlanVal = `toItemsList(ctx, planAttrValues["` + t.property.TFName() + `"])`
 		tfConfigVal = `toItemsList(ctx, configAttrValues["` + t.property.TFName() + `"])`
 	} else {
-		tfPlanVal = planValue + ".(basetypes.ObjectValue)"
-		tfConfigVal = configValue + ".(basetypes.ObjectValue)"
+		tfPlanVal = "toObjectValue(" + planValue + ")"
+		tfConfigVal = "toObjectValue(" + configValue + ")"
 	}
 
 	return "tfObjectToTKH" + t.nestedType.Suffix() + t.nestedType.GoTypeName() +

--- a/model/property_type_polymorphic_subtype.go
+++ b/model/property_type_polymorphic_subtype.go
@@ -100,9 +100,9 @@ func (t *restPolymorphicSubtype) TKHToTF(value string, listItem bool) string {
 		"(" + RecurseCutOff(t.property.Parent) + ", " + value + ")"
 }
 
-func (t *restPolymorphicSubtype) TFToTKH(value string, listItem bool) string {
+func (t *restPolymorphicSubtype) TFToTKH(planValue string, configValue string, listItem bool) string {
 	return "tfObjectToTKH" + t.nestedType.Suffix() + t.nestedType.GoTypeName() +
-		"(ctx, " + RecurseCutOff(t.property.Parent) + ", " + value + ".(basetypes.ObjectValue))"
+		"(ctx, " + RecurseCutOff(t.property.Parent) + ", " + planValue + ".(basetypes.ObjectValue), " + configValue + ".(basetypes.ObjectValue))"
 }
 
 func (t *restPolymorphicSubtype) TKHToTFGuard() string {
@@ -110,7 +110,11 @@ func (t *restPolymorphicSubtype) TKHToTFGuard() string {
 }
 
 func (t *restPolymorphicSubtype) TFToTKHGuard() string {
-	return "if !objAttrs[\"" + t.property.TFName() + "\"].IsNull() "
+	if t.property.IsValueFromConfig() {
+		return `if !configAttrValues["` + t.property.TFName() + `"].IsNull() `
+	} else {
+		return `if !planAttrValues["` + t.property.TFName() + `"].IsNull()`
+	}
 }
 
 func (t *restPolymorphicSubtype) TKHGetter(propertyName string) string {

--- a/model/property_type_simple.go
+++ b/model/property_type_simple.go
@@ -204,7 +204,14 @@ func (t *restSimpleType) TKHToTF(value string, listItem bool) string {
 	}
 }
 
-func (t *restSimpleType) TFToTKH(value string, listItem bool) string {
+func (t *restSimpleType) TFToTKH(planValue string, configValue string, listItem bool) string {
+	var value string
+	if t.property.IsValueFromConfig() {
+		value = configValue
+	} else {
+		value = planValue
+	}
+
 	openapiFormat := t.openapiSchema.Format
 	if listItem {
 		switch {

--- a/templates/impl/datasource.go.tmpl
+++ b/templates/impl/datasource.go.tmpl
@@ -73,7 +73,7 @@ func (d *{{ .Name }}DataSource) Read(ctx context.Context, req datasource.ReadReq
 
 	tflog.Debug(ctx, "Reading {{ .Name }} from Topicus KeyHub by UUID")
 	additionalBackup := data.Additional
-	additional, _ := tfToSliceList(data.Additional, func(val attr.Value, diags *diag.Diagnostics) string {
+	additional, _ := tfToSliceListUnary(data.Additional, func(val attr.Value, diags *diag.Diagnostics) string {
 		return val.(basetypes.StringValue).ValueString()
 	})
 	uuid := data.UUID.ValueString()

--- a/templates/impl/resource.go.tmpl
+++ b/templates/impl/resource.go.tmpl
@@ -38,7 +38,7 @@ type {{ .Name }}Resource struct {
 
 func (r *{{ .Name }}Resource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = ProviderName + "_{{ .NameUnderscore }}"
-	tflog.Info(ctx, "Registred resource "+resp.TypeName)
+	tflog.Info(ctx, "Registered resource "+resp.TypeName)
 }
 
 func (r *{{ .Name }}Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -76,7 +76,7 @@ func (r *{{ .Name }}Resource) Create(ctx context.Context, req resource.CreateReq
 
 	litter.Config.HidePrivateFields = false
 
-	tflog.Debug(ctx, "planData: "+litter.Sdump(planData))
+	tflog.Trace(ctx, "planData: "+litter.Sdump(planData))
 
 	var configData {{ .FullName }}DataRS
 	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
@@ -84,7 +84,7 @@ func (r *{{ .Name }}Resource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	tflog.Debug(ctx, "configData: "+litter.Sdump(configData))
+	tflog.Trace(ctx, "configData: "+litter.Sdump(configData))
 
 	ctx = context.WithValue(ctx, keyHubClientKey, r.providerData.Client)
 	planValues, diags := types.ObjectValueFrom(ctx, {{ .FullName }}AttrTypesRSRecurse, planData)
@@ -93,15 +93,11 @@ func (r *{{ .Name }}Resource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	tflog.Debug(ctx, "planValues: "+litter.Sdump(planValues))
-
 	configValues, diags := types.ObjectValueFrom(ctx, {{ .FullName }}AttrTypesRSRecurse, configData)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	tflog.Debug(ctx, "configValues: "+litter.Sdump(configValues))
 
 	newTkh, diags := tfObjectToTKHRS{{ .FullNameUp }}(ctx, true, planValues, configValues)
 	resp.Diagnostics.Append(diags...)

--- a/templates/impl/resource.go.tmpl
+++ b/templates/impl/resource.go.tmpl
@@ -238,7 +238,7 @@ func (r *{{ .Name }}Resource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	var configData {{ .FullName }}DataRS
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &configData)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/templates/impl/resource.go.tmpl
+++ b/templates/impl/resource.go.tmpl
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/sanity-io/litter"
 	keyhubmodels "github.com/topicuskeyhub/sdk-go/models"
 	keyhubreq "github.com/topicuskeyhub/sdk-go/{{ .ResourceBase }}"
 )
@@ -73,11 +74,17 @@ func (r *{{ .Name }}Resource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	litter.Config.HidePrivateFields = false
+
+	tflog.Debug(ctx, "planData: "+litter.Sdump(planData))
+
 	var configData {{ .FullName }}DataRS
 	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	tflog.Debug(ctx, "configData: "+litter.Sdump(configData))
 
 	ctx = context.WithValue(ctx, keyHubClientKey, r.providerData.Client)
 	planValues, diags := types.ObjectValueFrom(ctx, {{ .FullName }}AttrTypesRSRecurse, planData)
@@ -85,11 +92,16 @@ func (r *{{ .Name }}Resource) Create(ctx context.Context, req resource.CreateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	tflog.Debug(ctx, "planValues: "+litter.Sdump(planValues))
+
 	configValues, diags := types.ObjectValueFrom(ctx, {{ .FullName }}AttrTypesRSRecurse, configData)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	tflog.Debug(ctx, "configValues: "+litter.Sdump(configValues))
 
 	newTkh, diags := tfObjectToTKHRS{{ .FullNameUp }}(ctx, true, planValues, configValues)
 	resp.Diagnostics.Append(diags...)

--- a/templates/impl/resource.go.tmpl
+++ b/templates/impl/resource.go.tmpl
@@ -67,33 +67,44 @@ func (r *{{ .Name }}Resource) Configure(ctx context.Context, req resource.Config
 }
 
 func (r *{{ .Name }}Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var data {{ .FullName }}DataRS
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	var planData {{ .FullName }}DataRS
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var configData {{ .FullName }}DataRS
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	ctx = context.WithValue(ctx, keyHubClientKey, r.providerData.Client)
-	plannedState, diags := types.ObjectValueFrom(ctx, {{ .FullName }}AttrTypesRSRecurse, data)
+	planValues, diags := types.ObjectValueFrom(ctx, {{ .FullName }}AttrTypesRSRecurse, planData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	configValues, diags := types.ObjectValueFrom(ctx, {{ .FullName }}AttrTypesRSRecurse, configData)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	newTkh, diags := tfObjectToTKHRS{{ .FullNameUp }}(ctx, true, plannedState)
+	newTkh, diags := tfObjectToTKHRS{{ .FullNameUp }}(ctx, true, planValues, configValues)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	additionalBackup := data.Additional
+	additionalBackup := planData.Additional
 	r.providerData.Mutex.Lock()
 	defer r.providerData.Mutex.Unlock()
 	tflog.Info(ctx, "Creating Topicus KeyHub {{ .NameUnderscore }}")
 	newWrapper := keyhubmodels.New{{ .BaseNameUp }}LinkableWrapper()
 	newWrapper.SetItems([]keyhubmodels.{{ .BaseNameUp }}able{newTkh})
 {{- if .ParentResourceType }}
-	tkhParent, diags := find{{ .ParentResourceType }}ByUUID(ctx, data.{{ .ParentResourceNamePrefixUp }}UUID.ValueStringPointer())
+	tkhParent, diags := find{{ .ParentResourceType }}ByUUID(ctx, planData.{{ .ParentResourceNamePrefixUp }}UUID.ValueStringPointer())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -105,7 +116,7 @@ func (r *{{ .Name }}Resource) Create(ctx context.Context, req resource.CreateReq
 {{- end }}
 		ctx, newWrapper, &keyhubreq.{{ .CollectionRequestTypePrefix }}RequestBuilderPostRequestConfiguration{
 			QueryParameters: &keyhubreq.{{ .CollectionRequestTypePrefix }}RequestBuilderPostQueryParameters{
-				Additional: collectAdditional(ctx, data, data.Additional),
+				Additional: collectAdditional(ctx, planData, planData.Additional),
 			},
 		})
 	tkh, diags := findFirst[keyhubmodels.{{ .BaseNameUp }}able](ctx, wrapper, "{{ .NameUnderscore }}", nil, false, err)
@@ -121,37 +132,37 @@ func (r *{{ .Name }}Resource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 {{- if .ParentResourceType }}
-	postState = setAttributeValue(ctx, postState, "{{ .ParentResourceNamePrefixUnderscore }}_uuid", types.StringValue(data.{{ .ParentResourceNamePrefixUp }}UUID.ValueString()))
+	postState = setAttributeValue(ctx, postState, "{{ .ParentResourceNamePrefixUnderscore }}_uuid", types.StringValue(planData.{{ .ParentResourceNamePrefixUp }}UUID.ValueString()))
 {{- end }}
-	postState = reorder{{ .FullNameUp }}(postState, plannedState, true)
-	fillDataStructFromTFObjectRS{{ .FullNameUp }}(&data, postState)
-	data.Additional = additionalBackup
+	postState = reorder{{ .FullNameUp }}(postState, planValues, true)
+	fillDataStructFromTFObjectRS{{ .FullNameUp }}(&planData, postState)
+	planData.Additional = additionalBackup
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
 
 	tflog.Info(ctx, "Created a new Topicus KeyHub {{ .NameUnderscore }}")
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
 }
 
 func (r *{{ .Name }}Resource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var data {{ .FullName }}DataRS
-	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	var planData {{ .FullName }}DataRS
+	resp.Diagnostics.Append(req.State.Get(ctx, &planData)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	priorState, diags := types.ObjectValueFrom(ctx, {{ .FullName }}AttrTypesRSRecurse, data)
+	planValues, diags := types.ObjectValueFrom(ctx, {{ .FullName }}AttrTypesRSRecurse, planData)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	additionalBackup := data.Additional
+	additionalBackup := planData.Additional
 	r.providerData.Mutex.RLock()
 	defer r.providerData.Mutex.RUnlock()
 	ctx = context.WithValue(ctx, keyHubClientKey, r.providerData.Client)
 	tflog.Info(ctx, "Reading {{ .NameUnderscore }} from Topicus KeyHub")
 {{- if .ParentResourceType }}
-	tkhParent, diags := find{{ .ParentResourceType }}ByUUIDOrNil(ctx, data.{{ .ParentResourceNamePrefixUp }}UUID.ValueStringPointer())
+	tkhParent, diags := find{{ .ParentResourceType }}ByUUIDOrNil(ctx, planData.{{ .ParentResourceNamePrefixUp }}UUID.ValueStringPointer())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -169,8 +180,8 @@ func (r *{{ .Name }}Resource) Read(ctx context.Context, req resource.ReadRequest
 {{- end }}
 		ctx, &keyhubreq.{{ .CollectionRequestTypePrefix }}RequestBuilderGetRequestConfiguration{
 			QueryParameters: &keyhubreq.{{ .CollectionRequestTypePrefix }}RequestBuilderGetQueryParameters{
-				Additional: collectAdditional(ctx, data, data.Additional),
-				{{ .ReadIdentifierQuery }}: []string {data.{{ .ReadIdentifierStruct }}.ValueString()},
+				Additional: collectAdditional(ctx, planData, planData.Additional),
+				{{ .ReadIdentifierQuery }}: []string {planData.{{ .ReadIdentifierStruct }}.ValueString()},
 			},
 		})
 
@@ -178,7 +189,7 @@ func (r *{{ .Name }}Resource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	tkh, diags := findFirst[keyhubmodels.{{ .BaseNameUp }}able](ctx, wrapper, "{{ .NameUnderscore }}", data.{{ .ReadIdentifierStruct }}.ValueStringPointer(), true, err)
+	tkh, diags := findFirst[keyhubmodels.{{ .BaseNameUp }}able](ctx, wrapper, "{{ .NameUnderscore }}", planData.{{ .ReadIdentifierStruct }}.ValueStringPointer(), true, err)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -197,54 +208,66 @@ func (r *{{ .Name }}Resource) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 {{- if .ParentResourceType }}
-	postState = setAttributeValue(ctx, postState, "{{ .ParentResourceNamePrefixUnderscore }}_uuid", types.StringValue(data.{{ .ParentResourceNamePrefixUp }}UUID.ValueString()))
+	postState = setAttributeValue(ctx, postState, "{{ .ParentResourceNamePrefixUnderscore }}_uuid", types.StringValue(planData.{{ .ParentResourceNamePrefixUp }}UUID.ValueString()))
 {{- end }}
-	postState = reorder{{ .FullNameUp }}(postState, priorState, true)
-	fillDataStructFromTFObjectRS{{ .FullNameUp }}(&data, postState)
-	data.Additional = additionalBackup
+	postState = reorder{{ .FullNameUp }}(postState, planValues, true)
+	fillDataStructFromTFObjectRS{{ .FullNameUp }}(&planData, postState)
+	planData.Additional = additionalBackup
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
 }
 
 func (r *{{ .Name }}Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 {{- if .UpdateSupported }}
-	var data {{ .FullName }}DataRS
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	var planData {{ .FullName }}DataRS
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var configData {{ .FullName }}DataRS
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &configData)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	ctx = context.WithValue(ctx, keyHubClientKey, r.providerData.Client)
-	priorState, diags := types.ObjectValueFrom(ctx, {{ .FullName }}AttrTypesRSRecurse, data)
+	planValues, diags := types.ObjectValueFrom(ctx, {{ .FullName }}AttrTypesRSRecurse, planData)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	newTkh, diags := tfObjectToTKHRS{{ .FullNameUp }}(ctx, true, priorState)
+	configValues, diags := types.ObjectValueFrom(ctx, {{ .FullName }}AttrTypesRSRecurse, configData)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	additionalBackup := data.Additional
+	newTkh, diags := tfObjectToTKHRS{{ .FullNameUp }}(ctx, true, planValues, configValues)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	additionalBackup := planData.Additional
 	r.providerData.Mutex.Lock()
 	defer r.providerData.Mutex.Unlock()
 	tflog.Info(ctx, "Updating Topicus KeyHub {{ .NameUnderscore }}")
 {{- if .ParentResourceType }}
-	tkhParent, diags := find{{ .ParentResourceType }}ByUUID(ctx, data.{{ .ParentResourceNamePrefixUp }}UUID.ValueStringPointer())
+	tkhParent, diags := find{{ .ParentResourceType }}ByUUID(ctx, planData.{{ .ParentResourceNamePrefixUp }}UUID.ValueStringPointer())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	tkh, err := r.providerData.Client.{{ .ResourceBaseUp }}().By{{ .ResourceBaseUp }}idInt64(*tkhParent.GetLinks()[0].GetId()){{ .SubResourceReqMethod }}.By{{ .SubResourceBaseUp }}idInt64(getSelfLink(data.Links).ID.ValueInt64()).Put(
+	tkh, err := r.providerData.Client.{{ .ResourceBaseUp }}().By{{ .ResourceBaseUp }}idInt64(*tkhParent.GetLinks()[0].GetId()){{ .SubResourceReqMethod }}.By{{ .SubResourceBaseUp }}idInt64(getSelfLink(planData.Links).ID.ValueInt64()).Put(
 {{- else }}
-	tkh, err := r.providerData.Client.{{ .ResourceBaseUp }}().By{{ .ResourceBaseUp }}idInt64(getSelfLink(data.Links).ID.ValueInt64()).Put(
+	tkh, err := r.providerData.Client.{{ .ResourceBaseUp }}().By{{ .ResourceBaseUp }}idInt64(getSelfLink(planData.Links).ID.ValueInt64()).Put(
 {{- end }}
 		ctx, newTkh, &keyhubreq.{{ .ItemRequestTypePrefix }}RequestBuilderPutRequestConfiguration{
 			QueryParameters: &keyhubreq.{{ .ItemRequestTypePrefix }}RequestBuilderPutQueryParameters{
-				Additional: collectAdditional(ctx, data, data.Additional),
+				Additional: collectAdditional(ctx, planData, planData.Additional),
 			},
 		})
 
@@ -259,14 +282,14 @@ func (r *{{ .Name }}Resource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 {{- if .ParentResourceType }}
-	postState = setAttributeValue(ctx, postState, "{{ .ParentResourceNamePrefixUnderscore }}_uuid", types.StringValue(data.{{ .ParentResourceNamePrefixUp }}UUID.ValueString()))
+	postState = setAttributeValue(ctx, postState, "{{ .ParentResourceNamePrefixUnderscore }}_uuid", types.StringValue(planData.{{ .ParentResourceNamePrefixUp }}UUID.ValueString()))
 {{- end }}
-	postState = reorder{{ .FullNameUp }}(postState, priorState, true)
-	fillDataStructFromTFObjectRS{{ .FullNameUp }}(&data, postState)
-	data.Additional = additionalBackup
+	postState = reorder{{ .FullNameUp }}(postState, planValues, true)
+	fillDataStructFromTFObjectRS{{ .FullNameUp }}(&planData, postState)
+	planData.Additional = additionalBackup
 
 	tflog.Info(ctx, "Updated a Topicus KeyHub {{ .NameUnderscore }}")
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
 {{- else }}
 	resp.Diagnostics.AddError("Cannot update a {{ .NameUnderscore }}", "Topicus KeyHub does not support updating a {{ .NameUnderscore }} via Terraform. The requested changes are not applied.")
 {{- end }}
@@ -274,8 +297,8 @@ func (r *{{ .Name }}Resource) Update(ctx context.Context, req resource.UpdateReq
 
 func (r *{{ .Name }}Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 {{- if .DeleteSupported }}
-	var data {{ .FullName }}DataRS
-	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	var planData {{ .FullName }}DataRS
+	resp.Diagnostics.Append(req.State.Get(ctx, &planData)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -285,9 +308,9 @@ func (r *{{ .Name }}Resource) Delete(ctx context.Context, req resource.DeleteReq
 	ctx = context.WithValue(ctx, keyHubClientKey, r.providerData.Client)
 	tflog.Info(ctx, "Deleting {{ .NameUnderscore }} from Topicus KeyHub")
 {{- if .ParentResourceType }}
-	err := r.providerData.Client.{{ .ResourceBaseUp }}().By{{ .ResourceBaseUp }}idInt64(-1){{ .SubResourceReqMethod }}.By{{ .SubResourceBaseUp }}idInt64(-1).WithUrl(getSelfLink(data.Links).Href.ValueString()).Delete(ctx, nil)
+	err := r.providerData.Client.{{ .ResourceBaseUp }}().By{{ .ResourceBaseUp }}idInt64(-1){{ .SubResourceReqMethod }}.By{{ .SubResourceBaseUp }}idInt64(-1).WithUrl(getSelfLink(planData.Links).Href.ValueString()).Delete(ctx, nil)
 {{- else }}
-	err := r.providerData.Client.{{ .ResourceBaseUp }}().By{{ .ResourceBaseUp }}idInt64(-1).WithUrl(getSelfLink(data.Links).Href.ValueString()).Delete(ctx, nil)
+	err := r.providerData.Client.{{ .ResourceBaseUp }}().By{{ .ResourceBaseUp }}idInt64(-1).WithUrl(getSelfLink(planData.Links).Href.ValueString()).Delete(ctx, nil)
 {{- end }}
 	if !isHttpStatusCodeOk(ctx, 404, err, &resp.Diagnostics) {
 		return

--- a/templates/model/full-helpers.go.tmpl
+++ b/templates/model/full-helpers.go.tmpl
@@ -66,9 +66,23 @@ func tfToSliceListBinary[T any](planValue basetypes.ListValue, configValue baset
 	var diags diag.Diagnostics
 	planVals := planValue.Elements()
 	configVals := configValue.Elements()
-	ret := make([]T, 0, len(planVals))
-	for idx, curPlanVal := range planVals {
-		ret = append(ret, toValue(curPlanVal, configVals[idx], &diags))
+	planValsLen := len(planVals)
+	configValsLen := len(configVals)
+	maxLen := intMax(planValsLen, configValsLen)
+	ret := make([]T, 0, maxLen)
+	for i := 0; i < maxLen; i++ {
+		var curPlanVal = (attr.Value)(nil)
+		var curConfigVal = (attr.Value)(nil)
+
+		if i < planValsLen {
+			curPlanVal = planVals[i]
+		}
+
+		if i < configValsLen {
+			curConfigVal = configVals[i]
+		}
+		
+		ret = append(ret, toValue(curPlanVal, curConfigVal, &diags))
 	}
 	return ret, diags
 }
@@ -86,9 +100,23 @@ func tfToSliceSet[T any](planValue basetypes.SetValue, configValue basetypes.Set
 	var diags diag.Diagnostics
 	planVals := planValue.Elements()
 	configVals := configValue.Elements()
-	ret := make([]T, 0, len(planVals))
-	for idx, curPlanVal := range planVals {
-		ret = append(ret, toValue(curPlanVal, configVals[idx], &diags))
+	planValsLen := len(planVals)
+	configValsLen := len(configVals)
+	maxLen := intMax(planValsLen, configValsLen)
+	ret := make([]T, 0, maxLen)
+	for i := 0; i < maxLen; i++ {
+		var curPlanVal = (attr.Value)(nil)
+		var curConfigVal = (attr.Value)(nil)
+
+		if i < planValsLen {
+			curPlanVal = planVals[i]
+		}
+
+		if i < configValsLen {
+			curConfigVal = configVals[i]
+		}
+		
+		ret = append(ret, toValue(curPlanVal, curConfigVal, &diags))
 	}
 	return ret, diags
 }
@@ -780,4 +808,40 @@ func filterAttributes(attributes map[string]attr.Value, types map[string]attr.Ty
 		ret[k] = attributes[k]
 	}
 	return ret
+}
+
+func intMax(a int, b int) int {
+	if a < b {
+		return b
+	}
+	
+	return a
+}
+
+func toObjectValue(val attr.Value) basetypes.ObjectValue {
+	if val == nil {
+		return types.ObjectNull(make(map[string]attr.Type))
+	}
+	return val.(basetypes.ObjectValue)
+}
+
+func toListValue(val attr.Value) basetypes.ListValue {
+	if val == nil {
+		return types.ListNull(nil)
+	}
+	return val.(basetypes.ListValue)
+}
+
+func toSetValue(val attr.Value) basetypes.SetValue {
+	if val == nil {
+		return types.SetNull(nil)
+	}
+	return val.(basetypes.SetValue)
+}
+
+func toMapValue(val attr.Value) basetypes.MapValue {
+	if val == nil {
+		return types.MapNull(nil)
+	}
+	return val.(basetypes.MapValue)
 }

--- a/templates/model/full-helpers.go.tmpl
+++ b/templates/model/full-helpers.go.tmpl
@@ -52,12 +52,23 @@ func sliceToTFList[T any](elemType attr.Type, vals []T, toValue func(T, *diag.Di
 	return types.ListValue(elemType, ret)
 }
 
-func tfToSliceList[T any](val basetypes.ListValue, toValue func(attr.Value, *diag.Diagnostics) T) ([]T, diag.Diagnostics) {
+func tfToSliceListUnary[T any](values basetypes.ListValue, toValue func(attr.Value, *diag.Diagnostics) T) ([]T, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	vals := val.Elements()
+	vals := values.Elements()
 	ret := make([]T, 0, len(vals))
 	for _, curVal := range vals {
 		ret = append(ret, toValue(curVal, &diags))
+	}
+	return ret, diags
+}
+
+func tfToSliceListBinary[T any](planValue basetypes.ListValue, configValue basetypes.ListValue, toValue func(attr.Value, attr.Value, *diag.Diagnostics) T) ([]T, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	planVals := planValue.Elements()
+	configVals := configValue.Elements()
+	ret := make([]T, 0, len(planVals))
+	for idx, curPlanVal := range planVals {
+		ret = append(ret, toValue(curPlanVal, configVals[idx], &diags))
 	}
 	return ret, diags
 }
@@ -71,12 +82,13 @@ func sliceToTFSet[T any](elemType attr.Type, vals []T, toValue func(T, *diag.Dia
 	return types.SetValue(elemType, ret)
 }
 
-func tfToSliceSet[T any](val basetypes.SetValue, toValue func(attr.Value, *diag.Diagnostics) T) ([]T, diag.Diagnostics) {
+func tfToSliceSet[T any](planValue basetypes.SetValue, configValue basetypes.SetValue, toValue func(attr.Value, attr.Value, *diag.Diagnostics) T) ([]T, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	vals := val.Elements()
-	ret := make([]T, 0, len(vals))
-	for _, curVal := range vals {
-		ret = append(ret, toValue(curVal, &diags))
+	planVals := planValue.Elements()
+	configVals := configValue.Elements()
+	ret := make([]T, 0, len(planVals))
+	for idx, curPlanVal := range planVals {
+		ret = append(ret, toValue(curPlanVal, configVals[idx], &diags))
 	}
 	return ret, diags
 }
@@ -90,12 +102,13 @@ func mapToTF[T any](elemType attr.Type, vals map[string]T, toValue func(T, *diag
 	return types.MapValue(elemType, ret)
 }
 
-func tfToMap[T serialization.AdditionalDataHolder](val basetypes.MapValue, toValue func(attr.Value, *diag.Diagnostics) any, ret T) (T, diag.Diagnostics) {
+func tfToMap[T serialization.AdditionalDataHolder](planValue basetypes.MapValue, configValue basetypes.MapValue, toValue func(attr.Value, attr.Value, *diag.Diagnostics) any, ret T) (T, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	vals := val.Elements()
+	planVals := planValue.Elements()
+	configVals := configValue.Elements()
 	retMap := make(map[string]any)
-	for name, val := range vals {
-		retMap[name] = toValue(val, &diags)
+	for name, planVal := range planVals {
+		retMap[name] = toValue(planVal, configVals[name], &diags)
 	}
 	ret.SetAdditionalData(retMap)
 	return ret, diags
@@ -684,7 +697,7 @@ func setAttributeValue(ctx context.Context, tf basetypes.ObjectValue, key string
 
 func collectAdditional(ctx context.Context, data any, additional types.List) []string {
 	listValue, _ := additional.ToListValue(ctx)
-	ret, _ := tfToSliceList(listValue, func(val attr.Value, diags *diag.Diagnostics) string {
+	ret, _ := tfToSliceListUnary(listValue, func(val attr.Value, diags *diag.Diagnostics) string {
 		return val.(basetypes.StringValue).ValueString()
 	})
 	reflectValue := reflect.ValueOf(data)

--- a/templates/model/full-tf-to-tkh-ds.go.tmpl
+++ b/templates/model/full-tf-to-tkh-ds.go.tmpl
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/microsoft/kiota-abstractions-go/serialization"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/sanity-io/litter"
 	keyhubmodel "github.com/topicuskeyhub/sdk-go/models"
 )
 

--- a/templates/model/full-tf-to-tkh-rs.go.tmpl
+++ b/templates/model/full-tf-to-tkh-rs.go.tmpl
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/microsoft/kiota-abstractions-go/serialization"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/sanity-io/litter"
 	keyhubmodel "github.com/topicuskeyhub/sdk-go/models"
 )
 

--- a/templates/model/resource_schema_attr_simple.go.tmpl
+++ b/templates/model/resource_schema_attr_simple.go.tmpl
@@ -11,6 +11,9 @@ schemaAttrs["{{ .TFName }}"] = {{ .Type.RSSchemaTemplateData.Type }}{
 {{- else if eq .Type.RSSchemaTemplateData.Mode "Computed_UseStateForUnknown" }}
     Computed: true,
     PlanModifiers: []{{ .Type.RSSchemaTemplateData.PlanModifierType }}{ {{ .Type.RSSchemaTemplateData.PlanModifierPkg }}.UseStateForUnknown() },
+{{- else if eq .Type.RSSchemaTemplateData.Mode "WriteOnly" }}
+    WriteOnly: true,
+    Optional: true,
 {{- else }}
     {{ .Type.RSSchemaTemplateData.Mode }}: true,
 {{- if .Type.RequiresReplace }}
@@ -26,4 +29,5 @@ schemaAttrs["{{ .TFName }}"] = {{ .Type.RSSchemaTemplateData.Type }}{
 {{- if .Type.RSSchemaTemplateData.Sensitive }}
     Sensitive: true,
 {{- end }}
+
 }

--- a/templates/model/tf_object_to_tkh.go.tmpl
+++ b/templates/model/tf_object_to_tkh.go.tmpl
@@ -35,7 +35,7 @@ func tfObjectToTKH{{ .Suffix }}{{ .GoTypeName }}(ctx context.Context, recurse bo
         planAttrValues = planValues.Attributes()
     }
     configAttrValues := make(map[string]attr.Value)
-    if !missingPlanValues {
+    if !missingConfigValues {
         configAttrValues = configValues.Attributes()
     }
 

--- a/templates/model/tf_object_to_tkh.go.tmpl
+++ b/templates/model/tf_object_to_tkh.go.tmpl
@@ -22,14 +22,23 @@
 {{- end }}
 func tfObjectToTKH{{ .Suffix }}{{ .GoTypeName }}(ctx context.Context, recurse bool, planValues types.Object, configValues types.Object) ({{ .SDKTypeName }}, diag.Diagnostics) {
     var diags diag.Diagnostics
-    if planValues.IsNull() || planValues.IsUnknown() || configValues.IsNull() || configValues.IsUnknown() {
+    var missingPlanValues = planValues.IsNull() || planValues.IsUnknown()
+    var missingConfigValues = configValues.IsNull() || configValues.IsUnknown()
+    if missingPlanValues && missingConfigValues {
         return nil, diags
     }
 
 {{- $type := . }}
 {{- if .AllProperties }}
-    planAttrValues := planValues.Attributes()
-    configAttrValues := configValues.Attributes()
+    planAttrValues := make(map[string]attr.Value)
+    if !missingPlanValues {
+        planAttrValues = planValues.Attributes()
+    }
+    configAttrValues := make(map[string]attr.Value)
+    if !missingPlanValues {
+        configAttrValues = configValues.Attributes()
+    }
+
     // avoids the "declared but not used" compiler errors since we don't know beforehand which one we need
     _, _ = planAttrValues, configAttrValues
     litter.Config.HidePrivateFields = false

--- a/templates/model/tf_object_to_tkh.go.tmpl
+++ b/templates/model/tf_object_to_tkh.go.tmpl
@@ -18,15 +18,18 @@
     tkh.{{ .Property.TKHSetter }}({{ .Property.TFToTKH }})
 {{- end }}
 {{- end }}
-func tfObjectToTKH{{ .Suffix }}{{ .GoTypeName }}(ctx context.Context, recurse bool, objVal types.Object) ({{ .SDKTypeName }}, diag.Diagnostics) {
+func tfObjectToTKH{{ .Suffix }}{{ .GoTypeName }}(ctx context.Context, recurse bool, planValues types.Object, configValues types.Object) ({{ .SDKTypeName }}, diag.Diagnostics) {
     var diags diag.Diagnostics
-    if objVal.IsNull() || objVal.IsUnknown() {
+    if planValues.IsNull() || planValues.IsUnknown() || configValues.IsNull() || configValues.IsUnknown() {
         return nil, diags
     }
 
 {{- $type := . }}
 {{- if .AllProperties }}
-    objAttrs := objVal.Attributes()
+    planAttrValues := planValues.Attributes()
+    configAttrValues := configValues.Attributes()
+    // avoids the "declared but not used" compiler errors since we don't know beforehand which one we need
+    _, _ = planAttrValues, configAttrValues
 {{- end }}
     var tkh {{ .SDKTypeName }}
     tkh = {{ .SDKTypeConstructor }}

--- a/templates/model/tf_object_to_tkh.go.tmpl
+++ b/templates/model/tf_object_to_tkh.go.tmpl
@@ -42,8 +42,8 @@ func tfObjectToTKH{{ .Suffix }}{{ .GoTypeName }}(ctx context.Context, recurse bo
     // avoids the "declared but not used" compiler errors since we don't know beforehand which one we need
     _, _ = planAttrValues, configAttrValues
     litter.Config.HidePrivateFields = false
-    tflog.Debug(ctx, "planAttrValues: "+litter.Sdump(planAttrValues))
-    tflog.Debug(ctx, "configAttrValues: "+litter.Sdump(configAttrValues))
+    tflog.Trace(ctx, "planAttrValues: "+litter.Sdump(planAttrValues))
+    tflog.Trace(ctx, "configAttrValues: "+litter.Sdump(configAttrValues))
 {{- end }}
     var tkh {{ .SDKTypeName }}
     tkh = {{ .SDKTypeConstructor }}

--- a/templates/model/tf_object_to_tkh.go.tmpl
+++ b/templates/model/tf_object_to_tkh.go.tmpl
@@ -6,6 +6,7 @@
 {{- if .Property.Type.ToTKHCustomCode .Type }}
         {{ .Property.Type.ToTKHCustomCode .Type }}
 {{- else }}
+        tflog.Debug(ctx, "Setting " + litter.Sdump(val) + " using {{ .Property.TKHSetter }}")
         tkh.{{ .Property.TKHSetter }}(val)
 {{- end }}
 {{- if .Property.IsDTypeRequired }}
@@ -15,6 +16,7 @@
 {{- end }}
     }
 {{- else }}
+    tflog.Debug(ctx, "Setting " + litter.Sdump({{ .Property.TFToTKH }}) + " using {{ .Property.TKHSetter }}")
     tkh.{{ .Property.TKHSetter }}({{ .Property.TFToTKH }})
 {{- end }}
 {{- end }}
@@ -30,6 +32,9 @@ func tfObjectToTKH{{ .Suffix }}{{ .GoTypeName }}(ctx context.Context, recurse bo
     configAttrValues := configValues.Attributes()
     // avoids the "declared but not used" compiler errors since we don't know beforehand which one we need
     _, _ = planAttrValues, configAttrValues
+    litter.Config.HidePrivateFields = false
+    tflog.Debug(ctx, "planAttrValues: "+litter.Sdump(planAttrValues))
+    tflog.Debug(ctx, "configAttrValues: "+litter.Sdump(configAttrValues))
 {{- end }}
     var tkh {{ .SDKTypeName }}
     tkh = {{ .SDKTypeConstructor }}


### PR DESCRIPTION
- WriteOnly fields get their value from the config, not from the plan
- So we need to get both sets of values and pass these around so we can read the correct value when actually setting it on the attribute.
- In case of list and map fields we try to "merge" these when iterating over their values, since they can have different element sets. We assume one is always a subset/sublist/submap of the other. This required some null-safe handling for the missing values, however.
- Also added extra trace logging of these value sets